### PR TITLE
Named Savestates

### DIFF
--- a/MiniDebug.cs
+++ b/MiniDebug.cs
@@ -115,6 +115,7 @@ namespace MiniDebug
         // Misc fields
         private readonly List<Renderer> _invRenders = new List<Renderer>();
         private Vector3 _noclipPos;
+        public bool AcceptingInput { get; set; } = true;
 
         public delegate void UpdateEvent();
         public event UpdateEvent OnUpdate;
@@ -128,11 +129,14 @@ namespace MiniDebug
         {
             OnUpdate?.Invoke();
 
-            foreach ((string key, Action action) in _binds)
+            if (AcceptingInput)
             {
-                if (Input.GetKeyDown(key))
+                foreach ((string key, Action action) in _binds)
                 {
-                    action();
+                    if (Input.GetKeyDown(key))
+                    {
+                        action();
+                    }
                 }
             }
 
@@ -243,7 +247,7 @@ namespace MiniDebug
                 [Settings.noclip] = () => NoClip = !NoClip,
                 [Settings.yeetLoadScreens] = DestroyLoadScreens,
                 [Settings.showHitboxes] = () => HitboxManager.ShowHitboxes = !HitboxManager.ShowHitboxes,
-                [Settings.createSaveState] = SaveStateManager.CreateSaveState,
+                [Settings.createSaveState] = SaveStateManager.SaveState,
                 [Settings.loadSaveState] = () => SaveStateManager.LoadSaveState(false),
                 [Settings.loadSaveStateDuped] = () => SaveStateManager.LoadSaveState(true),
                 [Settings.kill] = () => HC.StartCoroutine("Die"),

--- a/MiniDebugMod.cs
+++ b/MiniDebugMod.cs
@@ -8,7 +8,7 @@ namespace MiniDebug
     {
         public static MiniDebugMod Instance { get; private set; }
 
-        public override string Version => "0.1.2";
+        public override string Version => "0.1.3";
 
         public MiniDebugMod() : base("Mini Debug")
         {


### PR DESCRIPTION
Makes savestates loadable by filename instead of number. Pressing "load savestate" when paused lists all states in the Savestates folder, letting you filter and select one to load. Pressing "load savestate" when not paused loads the last state loaded or created. 

Menuing controls are currently hard-coded to "enter" to select a state, "backspace" to edit filter, and "up arrow"/"down arrow" to move the cursor up or down the list. You can cancel the selection by pressing "escape" or clicking "continue".

Screenshot:
![image](https://user-images.githubusercontent.com/7276677/120911460-819fc100-c63c-11eb-936f-6578bf75b422.png)
